### PR TITLE
add RuleML+RR (Core B) conference

### DIFF
--- a/deadlines/static/data/conferences.json
+++ b/deadlines/static/data/conferences.json
@@ -108,6 +108,18 @@
     "type": "ML"
   },
   {
+  "id": "rulemlrr",
+  "name": "RuleML+ biomedical RR 2026",
+  "link": "https://2026.declarativeai.net/events/ruleml-rr",
+  "location": "Vilnius, Lithuania",
+  "location_link": null,
+  "date_start": "2026-08-24",
+  "date_end": "2026-08-26",
+  "deadline": "2026-05-15 23:59:59",
+  "timezone": "AoE",
+  "type": "DB"
+  },
+  {
     "id": "accv",
     "name": "ACCV 2026",
     "link": "https://accv2026.org",


### PR DESCRIPTION
RuleML+RR 2026 (Core B)

The 10th International Joint Conference on Rules and Reasoning

[RuleML+RR 2026](https://2026.declarativeai.net/events/ruleml-rr/cfp)
[Core ranking B](https://portal.core.edu.au/conf-ranks/2216/)
[dblp](https://dblp.org/db/conf/rulemlrr/index.html)